### PR TITLE
Fix(sec): upgrade netty-all to 4.1.44.Final

### DIFF
--- a/sidekick/pom.xml
+++ b/sidekick/pom.xml
@@ -63,7 +63,7 @@
         <jackson.version>2.12.6</jackson.version>
         <jackson-databind.version>2.12.6.1</jackson-databind.version>
         <javax.annotation.version>1.3.2</javax.annotation.version>
-        <netty.version>4.1.43.Final</netty.version>
+        <netty.version>4.1.44.Final</netty.version>
         <aws.sdk.version>1.11.811</aws.sdk.version>
         <json.version>20160810</json.version>
         <jbcrypt.version>0.4</jbcrypt.version>


### PR DESCRIPTION
Upgrade netty-all from 4.1.43.Final to 4.1.44.Final for vulnerability fix:
- [CVE-2020-7238](https://www.oscs1024.com/hd/MPS-2020-1320)
- [CVE-2019-20444](https://www.oscs1024.com/hd/MPS-2020-1526)
- [CVE-2019-20445](https://www.oscs1024.com/hd/MPS-2020-1527)