### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/sidekick/pom.xml
+++ b/sidekick/pom.xml
@@ -381,7 +381,7 @@
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
                         <transformers>
-                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                         </transformers>
                     </configuration>
                     <executions>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-all 4.1.43.Final
- [CVE-2020-7238](https://www.oscs1024.com/hd/CVE-2020-7238)




### What did I do？
Upgrade io.netty:netty-all from 4.1.43.Final to 4.1.44.Final for vulnerability fix



### What did you expect to happen？
Ideally, no insecure libs should be used.





### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS