### PR TITLE
fix(sec): upgrade io.springfox:springfox-swagger-ui to 2.10.0

### DIFF
--- a/sidekick/pom.xml
+++ b/sidekick/pom.xml
@@ -72,7 +72,7 @@
         <auth0.version>1.42.0</auth0.version>
         <auth0.spring.version>1.0.0</auth0.spring.version>
         <powermock.version>2.0.4</powermock.version>
-        <springfox-swagger.version>2.9.2</springfox-swagger.version>
+        <springfox-swagger.version>2.10.0</springfox-swagger.version>
         <jodd-core.version>5.0.13</jodd-core.version>
         <stripe.version>20.110.0</stripe.version>
     </properties>
@@ -381,7 +381,7 @@
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
                         <transformers>
-                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                         </transformers>
                     </configuration>
                     <executions>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.springfox:springfox-swagger-ui 2.9.2
- [CVE-2019-17495](https://www.oscs1024.com/hd/CVE-2019-17495)




### What did I do？
Upgrade io.springfox:springfox-swagger-ui from 2.9.2 to 2.10.0 for vulnerability fix



### What did you expect to happen？
Ideally, no insecure libs should be used.





### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS