### PR TITLE
fix(sec): upgrade org.json:json to 20180130

### DIFF
--- a/sidekick/pom.xml
+++ b/sidekick/pom.xml
@@ -65,7 +65,7 @@
         <javax.annotation.version>1.3.2</javax.annotation.version>
         <netty.version>4.1.44.Final</netty.version>
         <aws.sdk.version>1.11.811</aws.sdk.version>
-        <json.version>20160810</json.version>
+        <json.version>20180130</json.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <java.jwt.version>3.12.1</java.jwt.version>
         <jwks-rsa.version>0.3.0</jwks-rsa.version>
@@ -381,7 +381,7 @@
                     <configuration>
                         <createDependencyReducedPom>false</createDependencyReducedPom>
                         <transformers>
-                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                         </transformers>
                     </configuration>
                     <executions>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.json:json 20160810
- [MPS-2022-13520](https://www.oscs1024.com/hd/MPS-2022-13520)


### What did I do？
Upgrade org.json:json from 20160810 to 20180130 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS